### PR TITLE
added --config option to specify another location for encapsia settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Global --silent flag, for suppressing normal output. #55.
 - Print messages on successful completion for several commands. #55
 - Provide alternative options to --force (that will be deprecated soon): [--yes, --downgrade, --reinstall, --overwrite and --all]. #52
+- --config option to specify a different location for the config.toml file #57
 
 ## [0.5.3] - 2023-01-10
 

--- a/encapsia_cli/lib.py
+++ b/encapsia_cli/lib.py
@@ -39,12 +39,12 @@ def _get_shell_setenv_template(shell):
 
 
 def log(message="", nl=True):
-    if not click.get_current_context().obj["silent"]:
+    if not click.get_current_context().obj.get("silent"):
         click.secho(message, fg="yellow", nl=nl)
 
 
 def log_output(message=""):
-    if not click.get_current_context().obj["silent"]:
+    if not click.get_current_context().obj.get("silent"):
         click.secho(message, fg="green")
 
 


### PR DESCRIPTION
Behaviour is unchanged - it will create the config file and write the default content if it doesn't exist.